### PR TITLE
Fallback-aware failure handling - make sure snippet with enabled fall…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to `knotx-template-engine` will be documented in this file.
 
 ## Unreleased
 List of changes that are finished but not yet released in any final version.
-- [PR-5](https://github.com/Knotx/knotx-template-engine/pull/5) - implementation of [fallback handling](https://github.com/Cognifide/knotx/issues/466) in template engine
 
 ## 1.5.0
 Initial open source release.
+- [PR-5](https://github.com/Knotx/knotx-template-engine/pull/5) - implementation of [fallback handling](https://github.com/Cognifide/knotx/issues/466) in template engine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to `knotx-template-engine` will be documented in this file.
 
 ## Unreleased
 List of changes that are finished but not yet released in any final version.
+- [PR-5](https://github.com/Knotx/knotx-template-engine/pull/5) - implementation of [fallback handling](https://github.com/Cognifide/knotx/issues/466) in template engine
 
 ## 1.5.0
 Initial open source release.

--- a/core/src/main/java/io/knotx/te/core/TemplateEngineKnotProxy.java
+++ b/core/src/main/java/io/knotx/te/core/TemplateEngineKnotProxy.java
@@ -18,7 +18,7 @@ package io.knotx.te.core;
 import io.knotx.dataobjects.ClientResponse;
 import io.knotx.dataobjects.Fragment;
 import io.knotx.dataobjects.KnotContext;
-import io.knotx.exceptions.FragmentExecutionException;
+import io.knotx.exceptions.FragmentProcessingException;
 import io.knotx.knot.AbstractKnotProxy;
 import io.knotx.te.api.TemplateEngine;
 import io.knotx.te.core.exception.UnsupportedEngineException;
@@ -116,7 +116,7 @@ public class TemplateEngineKnotProxy extends AbstractKnotProxy {
     if (fragmentContext.fragment().fallback().isPresent()) {
       return fragmentContext;
     } else {
-      throw new FragmentExecutionException(String.format("Fragment processing failed in %s", SUPPORTED_FRAGMENT_ID), t);
+      throw new FragmentProcessingException(String.format("Fragment processing failed in %s", SUPPORTED_FRAGMENT_ID), t);
     }
   }
 }

--- a/it-test/src/test/resources/snippet/simple-missing-engine.txt
+++ b/it-test/src/test/resources/snippet/simple-missing-engine.txt
@@ -1,0 +1,7 @@
+<knotx:snippet knots="te"
+            te-strategy="missing-engine"
+            fallback="BLANK"
+            type="text/knotx-snippet">
+  <h2>Message - {{_result.message}}</h2>
+  <p>Info - {{_result.body.info}}</p>
+</knotx:snippet>


### PR DESCRIPTION
…back is processed

Implementation of https://github.com/Cognifide/knotx/issues/466 in Template Engine

## Description
Allows snippets with misconfigured template engine to be processed further by knotx if they have a fallback strategy assigned. Added relevant integration test

## Motivation and Context
see https://github.com/Cognifide/knotx/issues/466

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
N/A 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
