### PR TITLE
Remove hamcrest dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 before_script:
   - chmod +x ./gradlew
 script:

--- a/build.gradle
+++ b/build.gradle
@@ -70,10 +70,6 @@ subprojects { subproject ->
     testCompile 'org.junit.vintage:junit-vintage-engine'
     testCompile 'com.github.tomakehurst:wiremock'
 
-    // deprecated
-    testCompile 'uk.co.datumedge:hamcrest-json:0.2'
-    testCompile 'org.hamcrest:hamcrest-all:1.3'
-
     testCompileOnly 'io.vertx:vertx-codegen'
     testCompile 'io.vertx:vertx-config'
     testCompile 'io.vertx:vertx-junit5'

--- a/handlebars/build.gradle
+++ b/handlebars/build.gradle
@@ -30,8 +30,10 @@ dependencies {
   compile project(':knotx-template-engine-api')
   compile("com.github.jknack:handlebars:$handlebarsVersion")
 
+  testCompile group: 'io.knotx', name: 'knotx-junit5', version: "${project.version}"
   testCompile 'org.mockito:mockito-core'
   testCompile 'org.mockito:mockito-junit-jupiter'
+
 }
 
 

--- a/handlebars/src/test/java/io/knotx/te/handlebars/HandlebarsTemplateEngineTest.java
+++ b/handlebars/src/test/java/io/knotx/te/handlebars/HandlebarsTemplateEngineTest.java
@@ -1,7 +1,6 @@
 package io.knotx.te.handlebars;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
+import static io.knotx.junit5.assertions.KnotxAssertions.assertEqualsIgnoreWhitespace;
 import static org.mockito.Mockito.when;
 
 import io.knotx.fragment.Fragment;
@@ -34,7 +33,7 @@ class HandlebarsTemplateEngineTest {
         "data/sampleContext.json");
     final String result = templateEngine.process(fragment).trim();
     final String expected = FileReader.readText("results/simple").trim();
-    assertThat(result, equalToIgnoringWhiteSpace(expected));
+    assertEqualsIgnoreWhitespace(expected, result);
   }
 
   @Test
@@ -46,7 +45,7 @@ class HandlebarsTemplateEngineTest {
         "data/sampleContext.json");
     final String result = templateEngine.process(fragment).trim();
     final String expected = FileReader.readText("results/customDelimiter").trim();
-    assertThat(result, equalToIgnoringWhiteSpace(expected));
+    assertEqualsIgnoreWhitespace(expected, result);
   }
 
   @Test
@@ -56,7 +55,7 @@ class HandlebarsTemplateEngineTest {
         "data/emptyContext.json");
     final String result = templateEngine.process(fragment).trim();
     final String expected = FileReader.readText("results/emptyContext").trim();
-    assertThat(result, equalToIgnoringWhiteSpace(expected));
+    assertEqualsIgnoreWhitespace(expected, result);
   }
 
   @Test
@@ -66,7 +65,7 @@ class HandlebarsTemplateEngineTest {
         "data/sampleContext.json");
     final String result = templateEngine.process(fragment).trim();
     final String expected = FileReader.readText("results/emptyContent").trim();
-    assertThat(result, equalToIgnoringWhiteSpace(expected));
+    assertEqualsIgnoreWhitespace(expected, result);
   }
 
   @Test
@@ -76,7 +75,7 @@ class HandlebarsTemplateEngineTest {
         "data/sampleContext.json");
     final String result = templateEngine.process(fragment).trim();
     final String expected = FileReader.readText("results/undefinedHelper").trim();
-    assertThat(result, equalToIgnoringWhiteSpace(expected));
+    assertEqualsIgnoreWhitespace(expected, result);
   }
 
   private Fragment mockFragmentFromFile(String bodyFilePath, String contextFilePath)
@@ -90,4 +89,5 @@ class HandlebarsTemplateEngineTest {
 
     return mockedFragment;
   }
+
 }

--- a/handlebars/src/test/java/io/knotx/te/handlebars/JsonObjectValueResolverTest.java
+++ b/handlebars/src/test/java/io/knotx/te/handlebars/JsonObjectValueResolverTest.java
@@ -15,8 +15,7 @@
  */
 package io.knotx.te.handlebars;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.github.jknack.handlebars.Context;
 import com.github.jknack.handlebars.Handlebars;
@@ -47,7 +46,7 @@ class JsonObjectValueResolverTest {
         .build();
     String compiled = template.apply(context).trim();
 
-    assertThat(compiled, equalTo(expected));
+    assertEquals(expected, compiled);
   }
 
 

--- a/it-test/build.gradle
+++ b/it-test/build.gradle
@@ -23,6 +23,7 @@ dependencies {
   compile project(':knotx-template-engine-core')
   compile project(':knotx-template-engine-handlebars')
 
+  testCompile group: 'io.knotx', name: 'knotx-junit5', version: "${project.version}"
   testCompile group: 'io.knotx', name: 'knotx-launcher', version: "${project.version}"
 }
 

--- a/it-test/src/test/java/io/knotx/te/test/integration/TemplateEngineIntegrationTest.java
+++ b/it-test/src/test/java/io/knotx/te/test/integration/TemplateEngineIntegrationTest.java
@@ -1,8 +1,7 @@
 package io.knotx.te.test.integration;
 
+import static io.knotx.junit5.assertions.KnotxAssertions.assertEqualsIgnoreWhitespace;
 import static io.knotx.junit5.util.RequestUtil.subscribeToResult_shouldSucceed;
-import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
-import static org.junit.Assert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.knotx.fragment.Fragment;
@@ -44,7 +43,7 @@ class TemplateEngineIntegrationTest {
           final String markup = fragmentResult.getFragment().getBody();
 
           assertEquals(FragmentResult.SUCCESS_TRANSITION, fragmentResult.getTransition());
-          assertThat(markup, equalToIgnoringWhiteSpace(expectedMarkup));
+          assertEqualsIgnoreWhitespace(expectedMarkup, markup);
         });
   }
 
@@ -61,7 +60,7 @@ class TemplateEngineIntegrationTest {
           final String markup = fragmentResult.getFragment().getBody();
 
           assertEquals(FragmentResult.SUCCESS_TRANSITION, fragmentResult.getTransition());
-          assertThat(markup, equalToIgnoringWhiteSpace(expectedMarkup));
+          assertEqualsIgnoreWhitespace(expectedMarkup, markup);
         });
   }
 
@@ -133,4 +132,5 @@ class TemplateEngineIntegrationTest {
     return new String(Files.readAllBytes(Paths.get(getClass().getClassLoader()
         .getResource(filePath).toURI())));
   }
+
 }


### PR DESCRIPTION
## Description
Removing hamcrest deps as they generate unnecessary dependencies.

## Motivation and Context
Get rid of slf4j deps. See also https://github.com/Knotx/knotx-junit5/pull/29 .

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
